### PR TITLE
Change .example to .template

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ uv pip install -r pyproject.toml --all-extras
 To generate the synthetic CV data, you need an OpenAI API key.
 
 ```sh
-cp .env.example .env
+cp .env.template .env
 ```
 
 Then, edit the `.env` file to add your API key:


### PR DESCRIPTION
Slight typo in the readme, the env.example does not exist (but the env.template does)